### PR TITLE
Threat Modelling

### DIFF
--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -10,12 +10,13 @@ todo
 | --- | --- | --- | --- | --- | --- |
 | **1.1** | Verify that all app components are identified and are known to be needed. | ✓ | ✓ | ✓ | ✓ |
 | **1.2** | Verify that all third party components used by the app, such as libraries and frameworks, are identified. | ✓ | ✓ | ✓ | ✓ |
-| **1.3** | Verify that all third party components are assessed and evaluated (associated risks) before being used or implemented. Whenever a security update is published of an implemented third party component, the change has to be inspected and the risk has to be evaluated. In the case a third party component causes the app itself to be vulnerable, the app has to be fixed as soon as possible.  |   | ✓ | ✓ | ✓ |
-| **1.4** | Verify that all security controls (including libraries that call external security services) have a centralized implementation. |   | ✓ | ✓ | ✓ |
-| **1.5** | Verify that a high-level architecture for the mobile app and any connected remote services has been defined and that security has been addressed in that architecture. |   | ✓ | ✓ | ✓ |
-| **1.6** | Verify that all application components are defined in terms of the business functions and/or security functions they provide. |   | ✓ | ✓ | ✓ |
-| **1.7** | Verify that all components that are not part of the application but that the application relies on to operate are defined in terms of the functions, and/or security functions, they provide. |   | ✓ | ✓ | ✓ |
-| **1.8** | Verify that a threat model for the mobile app and any connected remote services has been produced. |   |   | ✓ | ✓ |
+| **1.3** | Verify that a high-level architecture for the mobile app and any connected remote services has been defined and that security has been addressed in that architecture. | ✓ | ✓ | ✓ | ✓ |
+| **1.4** | Verify that a threat model for the mobile app and any connected remote services has been produced to identiy potential threats and countermeasures to work against them. |  ✓ | ✓ | ✓ |
+| **1.5** | Verify that all third party components are assessed and evaluated (associated risks) before being used or implemented. Whenever a security update is published of an implemented third party component, the change has to be inspected and the risk has to be evaluated. |   | ✓ | ✓ | ✓ |
+| **1.6** | Verify that all security controls (including libraries that call external security services) have a centralized implementation. |   | ✓ | ✓ | ✓ |
+| **1.7** | Verify that all application components are defined in terms of the business functions and/or security functions they provide. |   | ✓ | ✓ | ✓ |
+| **1.8** | Verify that all components that are not part of the application but that the application relies on to operate are defined in terms of the functions, and/or security functions, they provide. |   | ✓ | ✓ | ✓ |
+ ✓ |
 
 ## References
 

--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -11,7 +11,7 @@ todo
 | **1.1** | Verify that all app components are identified and are known to be needed. | ✓ | ✓ | ✓ | ✓ |
 | **1.2** | Verify that all third party components used by the app, such as libraries and frameworks, are identified. | ✓ | ✓ | ✓ | ✓ |
 | **1.3** | Verify that a high-level architecture for the mobile app and any connected remote services has been defined and that security has been addressed in that architecture. | ✓ | ✓ | ✓ | ✓ |
-| **1.4** | Verify that a threat model for the mobile app and any connected remote services has been produced to identiy potential threats and countermeasures to work against them. | ✓ | ✓ | ✓ | ✓ |
+| **1.4** | Verify that a threat model for the mobile app and any connected remote services has been produced to identiy potential threats and countermeasures to work against them. |   | ✓ | ✓ | ✓ |
 | **1.5** | Verify that all third party components are assessed and evaluated (associated risks) before being used or implemented. Whenever a security update is published of an implemented third party component, the change has to be inspected and the risk has to be evaluated. |   | ✓ | ✓ | ✓ |
 | **1.6** | Verify that all security controls (including libraries that call external security services) have a centralized implementation. |   | ✓ | ✓ | ✓ |
 | **1.7** | Verify that all application components are defined in terms of the business functions and/or security functions they provide. |   | ✓ | ✓ | ✓ |

--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -11,12 +11,11 @@ todo
 | **1.1** | Verify that all app components are identified and are known to be needed. | ✓ | ✓ | ✓ | ✓ |
 | **1.2** | Verify that all third party components used by the app, such as libraries and frameworks, are identified. | ✓ | ✓ | ✓ | ✓ |
 | **1.3** | Verify that a high-level architecture for the mobile app and any connected remote services has been defined and that security has been addressed in that architecture. | ✓ | ✓ | ✓ | ✓ |
-| **1.4** | Verify that a threat model for the mobile app and any connected remote services has been produced to identiy potential threats and countermeasures to work against them. |  ✓ | ✓ | ✓ |
+| **1.4** | Verify that a threat model for the mobile app and any connected remote services has been produced to identiy potential threats and countermeasures to work against them. | ✓ | ✓ | ✓ | ✓ |
 | **1.5** | Verify that all third party components are assessed and evaluated (associated risks) before being used or implemented. Whenever a security update is published of an implemented third party component, the change has to be inspected and the risk has to be evaluated. |   | ✓ | ✓ | ✓ |
 | **1.6** | Verify that all security controls (including libraries that call external security services) have a centralized implementation. |   | ✓ | ✓ | ✓ |
 | **1.7** | Verify that all application components are defined in terms of the business functions and/or security functions they provide. |   | ✓ | ✓ | ✓ |
 | **1.8** | Verify that all components that are not part of the application but that the application relies on to operate are defined in terms of the functions, and/or security functions, they provide. |   | ✓ | ✓ | ✓ |
- ✓ |
 
 ## References
 


### PR DESCRIPTION
I would suggest to put the Threat Model already in Level 2. The Threat Model is the basis for many decisions on what security controls are needed and maybe not needed for Level 2, 3 and 4. 

I would also suggest to put the high level architecture diagram in Level 1 as the endpoints are already identified due to the other activities in Level 1. This is also a starting point for the Threat Model in Level 2 then. 

I would also suggest to keep the descriptions objective and not give any recommendations within it. Therfefore I deleted "in the case a third party component causes the app itself to be vulnerable, the app has to be fixed as soon as possible."

Let me know what you think. 